### PR TITLE
refac: Add interface ICustomerController to separate endpoint definition

### DIFF
--- a/apps/api/src/main/java/com/github/thorlauridsen/controller/CustomerController.java
+++ b/apps/api/src/main/java/com/github/thorlauridsen/controller/CustomerController.java
@@ -1,10 +1,8 @@
 package com.github.thorlauridsen.controller;
 
 import com.github.thorlauridsen.Customer;
-import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
 
 import java.util.UUID;
 
@@ -13,7 +11,8 @@ import java.util.UUID;
  * This class is a controller for the customer model.
  */
 @Controller
-public class CustomerController {
+public class CustomerController implements ICustomerController {
+
 
     /**
      * Get method for customer.
@@ -21,11 +20,7 @@ public class CustomerController {
      *
      * @return ResponseEntity of customer.
      */
-    @GetMapping("/customer")
-    @Operation(
-            summary = "Retrieve a customer",
-            description = "Retrieve a customer"
-    )
+    @Override
     public ResponseEntity<Customer> get() {
         Customer customer = new Customer(
                 UUID.randomUUID(),

--- a/apps/api/src/main/java/com/github/thorlauridsen/controller/ICustomerController.java
+++ b/apps/api/src/main/java/com/github/thorlauridsen/controller/ICustomerController.java
@@ -1,0 +1,22 @@
+package com.github.thorlauridsen.controller;
+
+import com.github.thorlauridsen.Customer;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public interface ICustomerController {
+
+    /**
+     * Get method for customer.
+     * This method returns a customer.
+     *
+     * @return ResponseEntity of customer.
+     */
+    @GetMapping("/customer")
+    @Operation(
+            summary = "Retrieve a customer",
+            description = "Retrieve a customer"
+    )
+    ResponseEntity<Customer> get();
+}


### PR DESCRIPTION
Add `ICustomerController` and move code for defining endpoint from `CustomerController` to this new interface. The purpose here is that endpoints and swagger documentation should be defined in `ICustomerController` while the endpoints are implemented in `CustomerController`. This creates an improved separation of concerns.