### PR TITLE
build: Enable local build cache for Gradle using root gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true


### PR DESCRIPTION
Enable local build cache for Gradle by adding `gradle.properties` in the root directory:
```
org.gradle.caching=true
```

The Gradle build cache is a way to increase build performance because it will re-use outputs produced by previous builds. It will store build outputs locally and allow subsequent builds to fetch these outputs from the cache when it knows that the inputs have not changed. This means we can save time building.

It is also possible to implement a remote build cache as well to increase build performance across machines. I will save that for a later commit.

https://docs.gradle.org/current/userguide/build_cache.html