### PR TITLE
build: Enable Gradle configuration cache in root gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
Enable [Gradle configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html) for this project.

This will improve build performance by caching the result of the configuration phase and reusing this for subsequent builds. This means that Gradle tasks can be executed faster if nothing has been changed that affects the build configuration. If you update a **build.gradle.kts** file, the build configuration has been affected.

This is not enabled by default, so it is enabled by defining this in the root [gradle.properties](gradle.properties) file:
```
org.gradle.configuration-cache=true
org.gradle.configuration-cache.parallel=true
```

Please be aware that this feature is not enabled by default because of some limitations. The configuration cache does not support all core Gradle plugins yet but this is work in progress. Also note that some Gradle dependencies may not work with the configuration cache, in that case you can disable the configuration cache for those dependencies.