### PR TITLE
feat: Add Docker and docker-compose.yml

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
 	// Liquibase core dependency for database migrations
 	runtimeOnly(local.liquibase.core)
 
+	// PostgreSQL database driver
+	runtimeOnly(local.postgres)
+
 	// Springdoc OpenAPI for providing Swagger documentation
 	implementation(local.springdoc.openapi.starter.webmvc)
 

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
-  application:
-    name: sample
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1}
+    username: ${SPRING_DATASOURCE_USERNAME:sa}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
 springdoc:
   api-docs:
     enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sample-db
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
+  api:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: spring-boot-java-api
+    depends_on:
+      - postgres
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/sample-db
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    image: spring-boot-java-sample:latest
+    ports:
+      - "8080:8080"
+    restart: unless-stopped

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+# Stage 1: Build the application using a Gradle image with JDK 21.
+FROM gradle:8.13.0-jdk21-corretto AS builder
+WORKDIR /home/gradle/project
+
+# Copy Gradle files from the correct locations.
+COPY gradlew gradlew.bat ./
+COPY gradle/wrapper/ gradle/wrapper/
+COPY gradle/local.versions.toml gradle/
+COPY settings.gradle.kts ./
+COPY build.gradle.kts ./
+
+# Make gradlew executable.
+RUN chmod +x gradlew
+
+# Download dependencies (this layer will be cached unless build files change).
+RUN ./gradlew --no-daemon dependencies
+
+# Copy the rest of the source code.
+COPY . .
+
+# Build the api subproject.
+# Exclude tests to speed up the build.
+RUN ./gradlew --no-daemon :api:clean :api:build -x test
+
+# Stage 2: Package the application into a runtime image using temurin JDK 21.
+FROM eclipse-temurin:21-jdk
+WORKDIR /app
+
+# Copy the generated jar from the builder stage.
+COPY --from=builder /home/gradle/project/apps/api/build/libs/api.jar app.jar
+
+# Run the application.
+CMD ["java", "-jar", "app.jar"]

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -2,6 +2,7 @@
 h2database = "2.3.232"
 junitPlatformLauncher = "1.11.4"
 liquibase = "4.31.1"
+postgres = "42.7.5"
 springboot = "3.4.4"
 springDependencyPlugin = "1.1.7"
 springdoc = "2.8.5"
@@ -16,6 +17,9 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 
 # Liquibase for managing database changelogs
 liquibase-core = { module = "org.liquibase:liquibase-core", version.ref = "liquibase" }
+
+# PostgreSQL for live database
+postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 
 # Spring Boot libraries
 springboot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springboot" }


### PR DESCRIPTION
- Add `Dockerfile` which will build a runnable docker image for the `api` subproject.
- Add PostgreSQL Gradle dependency.
- Update `application.yml` to include environment variables for the datasource. The default values will be for the H2 in-memory database but you can configure these environment variables to connect to a PostgreSQL database instead.
- Add `docker-compose.yml` which will run a PostgreSQL image and build the Spring Boot instance from the `Dockerfile` and run everything together.

This allows you to run the entire project with a PostgreSQL database using:
```
docker compose up -d
```