### PR TITLE
feat: Use Testcontainers for controller tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ to view the Swagger documentation.
 - [H2database](https://github.com/h2database/h2database) - Provides an in-memory database for simple local testing
 - [Liquibase](https://github.com/liquibase/liquibase) - Used to manage database schema changelogs
 - [Lombok](https://github.com/projectlombok/lombok) - Used to reduce boilerplate code
+- [Testcontainers](https://github.com/testcontainers) - Creates a temporary PostgreSQL database for tests
+
+## Testing
+You can run the tests for this project using the following command:
+```
+./gradlew test
+```
+Please note that this project uses
+[Testcontainers](https://github.com/testcontainers)
+to create a temporary PostgreSQL database for tests. This requires
+a local Docker instance to be running when executing the tests.
 
 ## Gradle best practices
 [kotlinlang.org](https://kotlinlang.org/docs/gradle-best-practices.html)

--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -29,8 +29,10 @@ dependencies {
 	// Springdoc OpenAPI for providing Swagger documentation
 	implementation(local.springdoc.openapi.starter.webmvc)
 
-	// Spring Boot test dependencies
+	// Spring Boot and Testcontainers test dependencies
 	testImplementation(local.springboot.starter.test)
+	testImplementation(local.springboot.testcontainers)
+	testImplementation(local.testcontainers.postgresql)
 
 	// JUnit platform launcher dependency for running JUnit tests
 	testRuntimeOnly(local.junit.platform.launcher)

--- a/apps/api/src/main/resources/application-postgres.yml
+++ b/apps/api/src/main/resources/application-postgres.yml
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/sample-db
+    username: postgres
+    password: postgres
+  liquibase:
+    enabled: true

--- a/apps/api/src/test/java/com/github/thorlauridsen/CustomerControllerTest.java
+++ b/apps/api/src/test/java/com/github/thorlauridsen/CustomerControllerTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static com.github.thorlauridsen.controller.BaseEndpoint.CUSTOMER_BASE_ENDPOINT;
@@ -18,6 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Test class for testing the CustomerController.
+ * This class extends the BaseMockMvc class so this will spin up a Spring Boot instance for the tests.
+ * A local Docker instance is required to run the tests as Testcontainers is used.
+ */
+@ActiveProfiles("postgres")
+@Import(TestContainerConfig.class)
 class CustomerControllerTest extends BaseMockMvc {
 
     @Autowired

--- a/apps/api/src/test/java/com/github/thorlauridsen/TestContainerConfig.java
+++ b/apps/api/src/test/java/com/github/thorlauridsen/TestContainerConfig.java
@@ -1,0 +1,25 @@
+package com.github.thorlauridsen;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainerConfig {
+
+    /**
+     * A PostgreSQLContainer bean to be used in tests.
+     * This uses Testcontainers to spin up a temporary PostgreSQL instance in a Docker container.
+     * The ServiceConnection annotation allows Spring Boot to automatically
+     * configure the datasource properties based on the container settings.
+     */
+    @Bean
+    @ServiceConnection
+    public PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>("postgres:17")
+                .withDatabaseName("sample-db")
+                .withUsername("postgres")
+                .withPassword("postgres");
+    }
+}

--- a/gradle/local.versions.toml
+++ b/gradle/local.versions.toml
@@ -8,6 +8,7 @@ postgres = "42.7.7"
 springboot = "3.5.5"
 springDependencyPlugin = "1.1.7"
 springdoc = "2.8.11"
+testcontainers = "1.21.3"
 
 [libraries]
 # H2 for an in-memory database
@@ -31,6 +32,10 @@ springboot-starter-jpa = { module = "org.springframework.boot:spring-boot-starte
 springboot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springboot" }
 springboot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation", version.ref = "springboot" }
 springboot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springboot" }
+springboot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers", version.ref = "springboot" }
+
+# Testcontainers for running PostgreSQL in tests
+testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
 
 # Springdoc provides swagger docs with support for Spring Web MVC
 springdoc-openapi-starter-webmvc = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }


### PR DESCRIPTION
[Testcontainers](https://github.com/testcontainers) allow us to spin up a temporary Docker image during tests. For this project, we will spin up a temporary PostgreSQL database to run the controller tests against a real PostgreSQL database instead of an in-memory H2 database. There are differences between PostgreSQL and H2 databases so if you plan to use a PostgreSQL database in production, it also makes sense to mimic this by using a PostgreSQL database in the tests. H2 databases are useful for quickly testing and running the system locally, but it is better to use Testcontainers to run a real PostgreSQL database for the controller tests.

Use Testcontainers for controller tests:
- Add Gradle dependencies to `local.versions.toml` and `api/build.gradle.kts`:
  - `org.springframework.boot:spring-boot-testcontainers`
  - `org.testcontainers:postgresql `
- Add `TestContainerConfig` which defines the PostgreSQL container and database settings.
- Add annotations `@Import(TestContainerConfig.class)` and `@ActiveProfiles("postgres")` to `CustomerControllerTest` to ensure that a PostgreSQL database is used for the tests.
- Add `application-postgres.yml` with connection settings for PostgreSQL.
- Update `README.md`.