### PR TITLE
refac: Use Lombok UtilityClass annotation in BaseEndpoint

### DIFF
--- a/apps/api/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
+++ b/apps/api/src/main/java/com/github/thorlauridsen/controller/BaseEndpoint.java
@@ -1,8 +1,11 @@
 package com.github.thorlauridsen.controller;
 
+import lombok.experimental.UtilityClass;
+
 /**
  * This class contains the base endpoint constant for the customer controller.
  */
+@UtilityClass
 public class BaseEndpoint {
     public static final String CUSTOMER_BASE_ENDPOINT = "/customers";
 }


### PR DESCRIPTION
Use Lombok `UtilityClass` annotation in `BaseEndpoint` because the class is an utility class with only a static constant.