### PR TITLE
refac: Use RestController and RestControllerAdvice for pure REST APIs

### DIFF
--- a/apps/api/src/main/java/com/github/thorlauridsen/controller/CustomerController.java
+++ b/apps/api/src/main/java/com/github/thorlauridsen/controller/CustomerController.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RestController;
 
 import static com.github.thorlauridsen.controller.BaseEndpoint.CUSTOMER_BASE_ENDPOINT;
 
@@ -20,7 +20,7 @@ import static com.github.thorlauridsen.controller.BaseEndpoint.CUSTOMER_BASE_END
  * overrides the methods defined in the interface with implementations.
  * The controller is responsible for converting data transfer objects to models and vice versa.
  */
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class CustomerController implements ICustomerController {
 

--- a/apps/api/src/main/java/com/github/thorlauridsen/exception/ControllerAdvisor.java
+++ b/apps/api/src/main/java/com/github/thorlauridsen/exception/ControllerAdvisor.java
@@ -13,8 +13,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.lang.NonNull;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -22,7 +22,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
  * Controller advisor for handling exceptions.
  * This ensures that whenever an exception is thrown, a proper error response is returned to the client.
  */
-@ControllerAdvice
+@RestControllerAdvice
 @Slf4j
 public class ControllerAdvisor extends ResponseEntityExceptionHandler {
 


### PR DESCRIPTION
We should always use the annotations `RestController` and `RestControllerAdvice` for pure REST APIs. This commit updates the Spring Boot annotations.